### PR TITLE
Adds no-sandbox option for AGL

### DIFF
--- a/runxdg.toml
+++ b/runxdg.toml
@@ -14,6 +14,7 @@ path = "/opt/chromium68/chrome"
 
 params = [
   "--in-process-gpu",
-  "--user-data-dir=/opt/chromium68/workdir"
+  "--user-data-dir=/opt/chromium68/workdir",
+  "--no-sandbox"
 ]
 


### PR DESCRIPTION
It crashed on 'ZygoteHostImpl::Init' without no-sandbox option as
AGL always runs as a root.

[SPEC-1978] Adapt webOS OSE chromium68 and WAM to meta-agl-lge
https://jira.automotivelinux.org/browse/SPEC-1978