### PR TITLE
Fixes crash in Halibut

### DIFF
--- a/conf.d/wgt/config.xml.in
+++ b/conf.d/wgt/config.xml.in
@@ -11,6 +11,7 @@
     <param name="homescreen" value="ws" />
   </feature>
   <feature name="urn:AGL:widget:required-permission">
+    <param name="urn:AGL:permission::public:display" value="required" />
     <param name="urn:AGL:permission::public:no-htdocs" value="required" />
   </feature>
 </widget>

--- a/runxdg.toml
+++ b/runxdg.toml
@@ -14,7 +14,6 @@ path = "/opt/chromium68/chrome"
 
 params = [
   "--in-process-gpu",
-  "--user-data-dir=/opt/chromium68/workdir",
   "--no-sandbox"
 ]
 


### PR DESCRIPTION
Supersede https://github.com/webosose/chromium-browser-service/pull/2 by creating pull request to `halibut` branch instead of `flounder`, as commented at https://github.com/webosose/chromium-browser-service/pull/2#pullrequestreview-260230653